### PR TITLE
fix: preserve third-party output when log-update is active

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "log-update-async-hook",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "log-update fork that uses async-exit-hook internally",
   "license": "MIT",
   "repository": "AndreyBelym/log-update-async-hook",

--- a/package.json
+++ b/package.json
@@ -8,11 +8,13 @@
     "name": "Andrey Belym",
     "email": "belym.a.2105@gmail.com"
   },
-  "contributors": [{
-    "name": "Sindre Sorhus",
-    "email": "sindresorhus@gmail.com",
-    "url": "sindresorhus.com"
-  }],
+  "contributors": [
+    {
+      "name": "Sindre Sorhus",
+      "email": "sindresorhus@gmail.com",
+      "url": "sindresorhus.com"
+    }
+  ],
   "scripts": {
     "test": "node test.js"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -7,21 +7,42 @@ var cliCursor = require('./cli-cursor');
 function main (stream) {
 	var prevLineCount = 0;
 
+	var streamWrite = stream.write;
+
+	var overridenWrite = function (...args) {
+		if (prevLineCount)
+			render.clear();
+
+		return streamWrite.apply(this, args);
+	};
+
 	var render = function () {
 		cliCursor.hide();
+
+		if (stream.write !== overridenWrite) {
+			streamWrite  = stream.write;
+			stream.write = overridenWrite
+		}
+		  
 		var out = [].join.call(arguments, ' ') + '\n';
+
 		out = wrapAnsi(out, process.stdout.columns || 80, {wordWrap: false});
-		stream.write(ansiEscapes.eraseLines(prevLineCount) + out);
+
+		streamWrite.call(stream, ansiEscapes.eraseLines(prevLineCount) + out);
+		
 		prevLineCount = out.split('\n').length;
 	};
 
 	render.clear = function () {
-		stream.write(ansiEscapes.eraseLines(prevLineCount));
+		streamWrite.call(stream, ansiEscapes.eraseLines(prevLineCount));
+
 		prevLineCount = 0;
 	};
 
 	render.done = function () {
 		prevLineCount = 0;
+		stream.write  = streamWrite;
+
 		cliCursor.show();
 	};
 

--- a/test.js
+++ b/test.js
@@ -17,6 +17,12 @@ const int = setInterval(() => {
 }, 100);
 
 setTimeout(logUpdate.done, 1000);
+
+setTimeout(() => {
+	console.log('some log');
+	console.error('some error');
+}, 2000);
+
 setTimeout(logUpdate.done, 3000);
 
 setTimeout(() => {


### PR DESCRIPTION
The stream write method now gets overridden to hide the spinner when some third-party code tries to write something to the same stream.
[log-update-async-hook-2.0.3.tar.gz](https://github.com/DevExpress/log-update-async-hook/files/8066657/log-update-async-hook-2.0.3.tar.gz)
